### PR TITLE
chore: remove deprecated plugin wrapper

### DIFF
--- a/src/main/java/top/mczhengyi/vditor/extension/VditorPostContentHandler.java
+++ b/src/main/java/top/mczhengyi/vditor/extension/VditorPostContentHandler.java
@@ -3,9 +3,9 @@ package top.mczhengyi.vditor.extension;
 import com.google.common.base.Throwables;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.pf4j.PluginWrapper;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
+import run.halo.app.plugin.PluginContext;
 import run.halo.app.plugin.ReactiveSettingFetcher;
 import run.halo.app.theme.ReactivePostContentHandler;
 import top.mczhengyi.vditor.bean.RenderConfig;
@@ -18,7 +18,7 @@ public class VditorPostContentHandler implements ReactivePostContentHandler {
 
     private final ReactiveSettingFetcher reactiveSettingFetcher;
 
-    private final PluginWrapper pluginWrapper;
+    private final PluginContext pluginContext;
 
     @Override
     public Mono<PostContentContext> handle(PostContentContext contentContext) {
@@ -27,7 +27,7 @@ public class VditorPostContentHandler implements ReactivePostContentHandler {
                     if (renderConfig.getEnableRender()&&
                         (!renderConfig.getOnlyMarkdown() || contentContext.getRawType().equals("markdown"))) {
                         var content = ScriptUtils.renderScript(renderConfig) + "\n" + contentContext.getContent();
-                        contentContext.setContent(ScriptUtils.setContentProperty(content, pluginWrapper));
+                        contentContext.setContent(ScriptUtils.setContentProperty(content, pluginContext));
                     }
                     return contentContext;
                 })

--- a/src/main/java/top/mczhengyi/vditor/extension/VditorSinglePageContentHandler.java
+++ b/src/main/java/top/mczhengyi/vditor/extension/VditorSinglePageContentHandler.java
@@ -4,9 +4,9 @@ import com.google.common.base.Throwables;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.pf4j.PluginWrapper;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
+import run.halo.app.plugin.PluginContext;
 import run.halo.app.plugin.ReactiveSettingFetcher;
 import run.halo.app.theme.ReactiveSinglePageContentHandler;
 import top.mczhengyi.vditor.bean.RenderConfig;
@@ -18,7 +18,8 @@ import top.mczhengyi.vditor.utils.ScriptUtils;
 public class VditorSinglePageContentHandler implements ReactiveSinglePageContentHandler {
     private final ReactiveSettingFetcher reactiveSettingFetcher;
 
-    private final PluginWrapper pluginWrapper;
+    private final PluginContext pluginContext;
+
     @Override
     public Mono<SinglePageContentContext> handle(SinglePageContentContext contentContext) {
         return reactiveSettingFetcher.fetch("render", RenderConfig.class)
@@ -27,7 +28,7 @@ public class VditorSinglePageContentHandler implements ReactiveSinglePageContent
                 if (renderConfig.getEnableRender() &&
                     (!renderConfig.getOnlyMarkdown() || contentContext.getRawType().equals("markdown"))) {
                     var content = ScriptUtils.renderScript(renderConfig) + "\n" + contentContext.getContent();
-                    contentContext.setContent(ScriptUtils.setContentProperty(content, pluginWrapper));
+                    contentContext.setContent(ScriptUtils.setContentProperty(content, pluginContext));
                 }
                 return contentContext;
             })

--- a/src/main/java/top/mczhengyi/vditor/utils/ScriptUtils.java
+++ b/src/main/java/top/mczhengyi/vditor/utils/ScriptUtils.java
@@ -1,7 +1,7 @@
 package top.mczhengyi.vditor.utils;
 
-import org.pf4j.PluginWrapper;
 import org.springframework.util.PropertyPlaceholderHelper;
+import run.halo.app.plugin.PluginContext;
 import top.mczhengyi.vditor.bean.RenderConfig;
 import java.util.Properties;
 
@@ -28,9 +28,9 @@ public class ScriptUtils {
         return script.getScript();
     }
 
-    public static String setContentProperty(String script, PluginWrapper pluginWrapper) {
+    public static String setContentProperty(String script, PluginContext pluginContext) {
         final Properties properties = new Properties();
-        properties.setProperty("version", pluginWrapper.getDescriptor().getVersion());
+        properties.setProperty("version", pluginContext.getVersion());
         return PROPERTY_PLACEHOLDER_HELPER.replacePlaceholders(script, properties);
     }
 }


### PR DESCRIPTION
### What this PR does?
移除对已过时的 PluginWrapper 的引用，Halo 2.18.0 版本后将不在支持从 BasePlugin 中获取 PluginWrapper ，也不再支持依赖注入 PluginWrapper，使用 PluginContext 代替

see also https://github.com/halo-dev/halo/pull/6243 for more details

```release-note
None
```