### PR TITLE
fix: add jQuery existence check to prevent PJAX event binding errors

### DIFF
--- a/src/main/resources/static/render.js
+++ b/src/main/resources/static/render.js
@@ -9,15 +9,16 @@ if (!window.vditorPjax) {
     } else {
         window.addEventListener('load', () => vditorRender.render())
     }
-    // 兼容 PJAX
-    $(document).on('pjax:complete', function() {
-        vditorRender.render()
-        console.log("[Vditor Render] PJAX END")
-    })
-    // 兼容 Jquery-Pjax
-    $(document).on('pjax:end', function() {
-        vditorRender.render()
-        console.log("[Vditor Render] PJAX END")
-    })
+    // 兼容 JQuery-PJAX
+    if (typeof $ !== 'undefined' && $ && typeof $.fn !== 'undefined') {
+        $(document).on('pjax:complete', function() {
+            vditorRender.render()
+            console.log("[Vditor Render] JQuery-PJAX END")
+        })
+        $(document).on('pjax:end', function() {
+            vditorRender.render()
+            console.log("[Vditor Render] JQuery-PJAX END")
+        })
+    }
     console.log("[Vditor Render] PJAX Injected")
 }


### PR DESCRIPTION
fix #69 

```
// ...existing code...
if (typeof $ !== 'undefined' && $ && typeof $.fn !== 'undefined') {
    // ...existing code...
}
// ...existing code...
```

解释：
- `typeof $ !== 'undefined'` : 检查全局变量 $ 是否存在，确保 jQuery 已经加载。
- `$` : 检查 $ 是否为真值，防止 $ 被赋值为 null 或其他假值。
- `typeof $.fn !== 'undefined'` : 检查 $ 是否为 jQuery 对象，因为 jQuery 的原型方法都挂载在 $.fn 上。如果 $ 被其他库占用（比如 Zepto、Prototype），可能没有 $.fn，这时不是 jQuery。