### PR TITLE
Update CD workflow to use plugin-cd.yaml@v4

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   cd:
-    uses: halo-sigs/reusable-workflows/.github/workflows/plugin-cd.yaml@v3
+    uses: halo-sigs/reusable-workflows/.github/workflows/plugin-cd.yaml@v4
     secrets:
       halo-pat: ${{ secrets.HALO_PAT }}
     permissions:


### PR DESCRIPTION
Fix https://github.com/justice2001/halo-plugin-vditor/actions/runs/31660292987/job/94323651521